### PR TITLE
Fix: update `cacti-setup-wizard-debian-Ubuntu.sh` to make it compatible with cacti 1.2.26 on Ubuntu 22.04 and PHP 8.

### DIFF
--- a/cacti-setup-wizard-debian-Ubuntu.sh
+++ b/cacti-setup-wizard-debian-Ubuntu.sh
@@ -20,8 +20,8 @@
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.#
 
 
-echo "this script requires git"
-apt-get install git  -y
+echo "this script requires git and wget"
+apt-get install git wget  -y
 
 
 

--- a/cacti-setup-wizard-debian-Ubuntu.sh
+++ b/cacti-setup-wizard-debian-Ubuntu.sh
@@ -59,7 +59,7 @@ fi
 
 echo "cacti requires a LAMP stack as well as some required plugins we will now install the required packages"
 apt-get update
-apt-get  install -y apache2 libapache2-mod-php  rrdtool mariadb-server snmp snmpd php php-mysql  libapache2-mod-php   php-snmp php-xml php-mbstring php-json php-gd php-gmp php-zip php-ldap 
+apt-get  install -y apache2 libapache2-mod-php  rrdtool mariadb-server snmp snmpd php php-mysql  libapache2-mod-php   php-snmp php-xml php-mbstring php-json php-gd php-gmp php-zip php-ldap php-intl 
 
 
 

--- a/cacti-setup-wizard-debian-Ubuntu.sh
+++ b/cacti-setup-wizard-debian-Ubuntu.sh
@@ -164,18 +164,16 @@ cp $location/cacti/include/config.php.dist $location/cacti/include/config.php
 
 
 ##Adding Maria DB conf  
+echo "max_heap_table_size = 128M"    >>  /etc/mysql/mariadb.conf.d/50-server.cnf
+echo "tmp_table_size = 128M"         >>  /etc/mysql/mariadb.conf.d/50-server.cnf
+echo "innodb_buffer_pool_size = 2048M" >>  /etc/mysql/mariadb.conf.d/50-server.cnf
+echo "innodb_doublewrite=OFF" >>  /etc/mysql/mariadb.conf.d/50-server.cnf
 echo "innodb_flush_log_at_timeout = 4" >>  /etc/mysql/mariadb.conf.d/50-server.cnf
 echo "innodb_read_io_threads = 34"   >>  /etc/mysql/mariadb.conf.d/50-server.cnf
 echo "innodb_write_io_threads = 17" >> /etc/mysql/mariadb.conf.d/50-server.cnf
-echo "max_heap_table_size = 70M"    >>  /etc/mysql/mariadb.conf.d/50-server.cnf
-echo "tmp_table_size = 70M"         >>  /etc/mysql/mariadb.conf.d/50-server.cnf
-echo "join_buffer_size = 130M" >>  /etc/mysql/mariadb.conf.d/50-server.cnf
-echo "innodb_buffer_pool_size = 250M" >>  /etc/mysql/mariadb.conf.d/50-server.cnf
 echo "innodb_io_capacity = 5000" >>  /etc/mysql/mariadb.conf.d/50-server.cnf
 echo "innodb_io_capacity_max = 10000" >>  /etc/mysql/mariadb.conf.d/50-server.cnf
-echo "innodb_file_format = Barracuda" >>  /etc/mysql/mariadb.conf.d/50-server.cnf
-echo "innodb_large_prefix = 1" >>  /etc/mysql/mariadb.conf.d/50-server.cnf
-
+echo "collation-server = utf8mb4_unicode_ci" >>  /etc/mysql/mariadb.conf.d/50-server.cnf
 
 systemctl restart mysql
 


### PR DESCRIPTION
- Add missing dependencies and update configuration settings to meet the requirements for Cacti 1.2.26.
- Successfully tested on Ubuntu 22.04.